### PR TITLE
Fix player removal

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -24,7 +24,7 @@ const removePlayer = (socketId: Socket["id"]): void => {
   const playersArray = Array.from(players as Iterable<Player>);
 
   const playerToRemoveIndex = playersArray.findIndex(
-    (player) => (player.socketId = socketId),
+    (player) => (player.socketId === socketId),
   );
 
   players.clear();


### PR DESCRIPTION
In `findIndex`, the comparison was not set up properly, so it was presumably returning `true` for the first item in the array, rather than finding by socket ID. This mean that the first player would always be removed on a socket disconnect rather than the player who left

Closes #11