### PR TITLE
Turn off noNodejsModules rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,9 @@
 			"all": true,
 			"nursery": {
 				"all": false
+			},
+			"correctness": {
+				"noNodejsModules": "off"
 			}
 		}
 	},


### PR DESCRIPTION
We are not developing solely on the clientside so this rule is not helpful