### PR TITLE
Separate "turn" responsibility to TurnMachine

### DIFF
--- a/server/machines/round.ts
+++ b/server/machines/round.ts
@@ -1,29 +1,15 @@
 import { assign, setup } from "xstate";
-import type { Answer, Question } from "../@types/entities";
+import type { Question } from "../@types/entities";
 import questions from "../data/questions.json";
 
 const context = {
-	answers: [] as Answer[],
 	questions: questions as Question[],
 	selectedQuestion: {} as Question | undefined,
 };
 
 type Context = typeof context;
 
-type PlayerSubmitsAnswerEvent = {
-	type: "playerSubmitsAnswer";
-	answer: Answer;
-};
-
-type Events = PlayerSubmitsAnswerEvent;
-
 const dynamicParamFuncs = {
-	addAnswer: ({
-		context,
-		event,
-	}: { context: Context; event: PlayerSubmitsAnswerEvent }) => {
-		return { currentAnswers: context.answers, newAnswer: event.answer };
-	},
 	setQuestion: ({ context }: { context: Context }) => {
 		return { questions: context.questions };
 	},
@@ -32,17 +18,9 @@ const dynamicParamFuncs = {
 const roundMachine = setup({
 	types: {} as {
 		context: Context;
-		events: Events;
 	},
 
 	actions: {
-		// add this one to dynamicParamFuncs
-		addAnswer: assign({
-			answers: (_, params: ReturnType<typeof dynamicParamFuncs.addAnswer>) => [
-				...params.currentAnswers,
-				params.newAnswer,
-			],
-		}),
 		setQuestion: assign({
 			selectedQuestion: (
 				_,
@@ -58,26 +36,11 @@ const roundMachine = setup({
 }).createMachine({
 	context,
 	id: "round",
-	initial: "roundStart",
+	initial: "turn",
 	states: {
-		roundStart: {
+		turn: {
 			entry: [{ type: "setQuestion", params: dynamicParamFuncs.setQuestion }],
-			on: {
-				playerSubmitsAnswer: {
-					actions: { type: "addAnswer", params: dynamicParamFuncs.addAnswer },
-					target: "countdown",
-				},
-			},
 		},
-		countdown: {
-			on: {
-				playerSubmitsAnswer: {
-					actions: { type: "addAnswer", params: dynamicParamFuncs.addAnswer },
-				},
-			},
-			after: { [15000]: { target: "finished" } },
-		},
-		finished: { type: "final" },
 	},
 });
 

--- a/server/machines/turn.ts
+++ b/server/machines/turn.ts
@@ -1,0 +1,65 @@
+import { assign, setup } from "xstate";
+import type { Answer, Question } from "../@types/entities";
+
+const context = {
+	answers: [] as Answer[],
+	selectedQuestion: {} as Question | undefined,
+};
+
+type Context = typeof context;
+
+type PlayerSubmitsAnswerEvent = {
+	type: "playerSubmitsAnswer";
+	answer: Answer;
+};
+
+type Events = PlayerSubmitsAnswerEvent;
+
+const dynamicParamFuncs = {
+	addAnswer: ({
+		context,
+		event,
+	}: { context: Context; event: PlayerSubmitsAnswerEvent }) => {
+		return { currentAnswers: context.answers, newAnswer: event.answer };
+	},
+};
+
+const turnMachine = setup({
+	types: {} as {
+		context: Context;
+		events: Events;
+	},
+	actions: {
+		addAnswer: assign({
+			answers: (_, params: ReturnType<typeof dynamicParamFuncs.addAnswer>) => [
+				...params.currentAnswers,
+				params.newAnswer,
+			],
+		}),
+	},
+}).createMachine({
+	context,
+	id: "turn",
+	initial: "noAnswers",
+	states: {
+		noAnswers: {
+			on: {
+				playerSubmitsAnswer: {
+					actions: { type: "addAnswer", params: dynamicParamFuncs.addAnswer },
+					target: "answerSubmitted",
+				},
+			},
+		},
+		answerSubmitted: {
+			on: {
+				playerSubmitsAnswer: {
+					actions: { type: "addAnswer", params: dynamicParamFuncs.addAnswer },
+				},
+			},
+			after: { [15000]: { target: "finished" } },
+		},
+		finished: { type: "final" },
+	},
+});
+
+export { turnMachine };


### PR DESCRIPTION
The RoundMachine was handling events relating to a "turn" like a person answering a question, so we're extracting it out into its own machine here.

There's a bit of tidyup that needs doing:
1. Move the `addAnswer` function onto a new `turn` model
2. Why is `this.turnMachine` not providing type safety in `addAnswer`?