### PR TITLE
Mark answers at end of turn

### DIFF
--- a/server/models/round.ts
+++ b/server/models/round.ts
@@ -43,6 +43,19 @@ class Round {
 					.selectedQuestion as Question,
 			},
 		});
+		this.turnMachine.subscribe((state) => {
+			switch (state.value) {
+				case "finished": {
+					// TODO:
+					// - add logic for updating scores then checking if there's a clear winner in the round machine
+					// - delete the console.info below
+					console.info(
+						"turn machine finished with context:",
+						this.turnMachine?.getSnapshot().context,
+					);
+				}
+			}
+		});
 		this.turnMachine.start();
 	}
 


### PR DESCRIPTION
We iterate through the submitted answers and compare them with the correct answer, then record the correct players' socket IDs in the context. We will then be able to read the context in the round model and update its context (in a later piece of work)