### PR TITLE
Add fractional second digits to logging

### DIFF
--- a/server/utils/loggingUtils.ts
+++ b/server/utils/loggingUtils.ts
@@ -28,7 +28,12 @@ const logWithTime = (
 	subsequentLinesString?: string,
 	additionalLogCallback?: () => void,
 ) => {
-	const currentTime = new Date().toLocaleTimeString("en-GB");
+	const currentTime = new Date().toLocaleTimeString("en-GB", {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		fractionalSecondDigits: 3,
+	});
 
 	console.info(
 		[`\n${currentTime} ${inlineString}`, subsequentLinesString]


### PR DESCRIPTION
If one state follows another without user interaction this often happens in the sub-millisecond range so it's difficult to tell which happens first. This gives us more accuracy.