### PR TITLE
Add SocketIO package to externals

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -122,6 +122,6 @@
       src="https://cdn.socket.io/4.1.2/socket.io.min.js"
       crossorigin="anonymous"
     ></script>
-    <script src="assets/scripts/index.js"></script>
+    <script src="assets/scripts/index.js" type="module"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"repository": "git@github.com:dxw/js-cop-games.git",
 	"license": "MIT",
 	"scripts": {
-		"compile": "bun build ./client/index.ts --outdir ./client/assets/scripts",
+		"compile": "bun build ./client/index.ts --outdir ./client/assets/scripts --external 'socket.io-client'",
 		"lint:ts": "bunx @biomejs/biome check .",
 		"lint:ts:fix": "bunx @biomejs/biome check --write .",
 		"lint:css": "bunx stylelint \"client/assets/styles/*.css\"",


### PR DESCRIPTION
This package is imported via index.html and we are just using the types here. But if we don't tell the bundler that it's externally imported it then it will add it to the bundled code making a bigger and harder to scan bundle.
Docs: https://bun.sh/docs/bundler#external