### PR TITLE
Move reset round behind Konami code

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -4,6 +4,7 @@ import type {
 	ClientboundSocketServerEvents,
 	ServerboundSocketServerEvents,
 } from "../server/@types/events";
+import { addAdminModeListener } from "./utils/adminUtils";
 import type { NameFormElement } from "./utils/domManipulationUtils";
 import { renderBonusPoints } from "./utils/domManipulationUtils/bonusPoints";
 import { renderColourCheckboxes } from "./utils/domManipulationUtils/colourCheckboxes";
@@ -26,10 +27,7 @@ import {
 	resetPlayerNameFormValue,
 } from "./utils/domManipulationUtils/playerName";
 import { renderQuestion } from "./utils/domManipulationUtils/question";
-import {
-	renderRoundResetButton,
-	resetRound,
-} from "./utils/domManipulationUtils/roundReset";
+import { resetRound } from "./utils/domManipulationUtils/roundReset";
 import {
 	derenderStartButton,
 	renderStartButton,
@@ -96,7 +94,7 @@ socket.on("round:reset", () => {
 
 socket.on("round:start", () => {
 	derenderStartButton();
-	renderRoundResetButton();
+	addAdminModeListener();
 });
 
 socket.on("round:startable", () => {

--- a/client/utils/adminUtils.ts
+++ b/client/utils/adminUtils.ts
@@ -1,0 +1,39 @@
+import { renderRoundResetButton } from "./domManipulationUtils/roundReset";
+
+const konamiCode: KeyboardEvent["key"][] = [
+	"ArrowUp",
+	"ArrowUp",
+	"ArrowDown",
+	"ArrowDown",
+	"ArrowLeft",
+	"ArrowRight",
+	"ArrowLeft",
+	"ArrowRight",
+	"b",
+	"a",
+];
+
+const turnAdminModeOn = (): void => {
+	renderRoundResetButton();
+};
+
+const addAdminModeListener = (): void => {
+	let konamiCodePosition = 0;
+
+	document.addEventListener("keydown", (event) => {
+		const nextKey = konamiCode[konamiCodePosition];
+
+		if (event.key === nextKey) {
+			konamiCodePosition++;
+
+			if (konamiCodePosition === konamiCode.length) {
+				turnAdminModeOn();
+				konamiCodePosition = 0;
+			}
+		} else {
+			konamiCodePosition = 0;
+		}
+	});
+};
+
+export { addAdminModeListener, konamiCode };

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1,4 +1,5 @@
 import { type BrowserContext, type Page, expect, test } from "@playwright/test";
+import { konamiCode } from "../client/utils/adminUtils";
 import type { Colour, Player } from "../server/@types/entities";
 
 const joinedPlayerNames: Player["name"][] = [];
@@ -16,6 +17,11 @@ test.beforeEach(async ({ browser }) => {
 });
 
 test.afterEach(async () => {
+	// biome-ignore lint/complexity/noForEach: this doesn't work with a for ... of loop
+	konamiCode.forEach(async (key) => {
+		await playersPages[0].keyboard.down(key);
+	});
+
 	await playersPages[0].getByRole("button", { name: "Reset round" }).click();
 
 	for (const context of contexts) {


### PR DESCRIPTION
Users will now need to enter the Konami code (up, up, down, down, left, right, left, right, b, a) to see the reset round button

Based on: https://stackoverflow.com/a/31627191
See: https://en.wikipedia.org/wiki/Konami_Code